### PR TITLE
URI Schemes add-on

### DIFF
--- a/demos/urischemes.html
+++ b/demos/urischemes.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8"/>
+	<title>Demo: URI Schemes &ndash; YAML CSS Framework</title>
+
+	<link href="../yaml/add-ons/urischemes/urischemes.css" rel="stylesheet" type="text/css"/>
+</head>
+<body>
+	<pre>
+		<a href="tel:+49-89-18956731">+49 89 18956731</a>
+		<a class="email" href="mailto:Markus%20Malkusch%20%3Cmarkus%40malkusch.de%3E">markus@malkusch.de</a>
+		<a href="bitcoin:1335STSwu9hST4vcMRppEPgENMHD2r1REK">1335STSwu9hST4vcMRppEPgENMHD2r1REK</a>
+	</pre>
+</body>

--- a/sass/yaml-sass/add-ons/urischemes/_urischemes.scss
+++ b/sass/yaml-sass/add-ons/urischemes/_urischemes.scss
@@ -1,0 +1,20 @@
+/**
+ * "Yet Another Multicolumn Layout" - YAML CSS Framework
+ *
+ * YAML-Addon:URI Schemes
+ */
+@media all {
+	
+	a[href^="tel:"]:BEFORE {
+		content: "☎ ";
+	}
+
+	a[href^="bitcoin:"]:BEFORE {
+		content: "B⃦ ";
+	}
+
+	a[href^="mailto:"]:BEFORE {
+		content: "✉ ";
+	}
+
+}

--- a/yaml/add-ons/urischemes/urischemes.css
+++ b/yaml/add-ons/urischemes/urischemes.css
@@ -1,20 +1,15 @@
+@charset "UTF-8";
 /**
  * "Yet Another Multicolumn Layout" - YAML CSS Framework
  *
  * YAML-Addon:URI Schemes
  */
 @media all {
-	
-	a[href^="tel:"]:BEFORE {
-		content: "☎ ";
-	}
+  a[href^="tel:"]:BEFORE {
+    content: "☎ "; }
 
-	a[href^="bitcoin:"]:BEFORE {
-		content: "B⃦ ";
-	}
+  a[href^="bitcoin:"]:BEFORE {
+    content: "B⃦ "; }
 
-	a[href^="mailto:"]:BEFORE {
-		content: "✉ ";
-	}
-
-}
+  a[href^="mailto:"]:BEFORE {
+    content: "✉ "; } }

--- a/yaml/add-ons/urischemes/urischemes.css
+++ b/yaml/add-ons/urischemes/urischemes.css
@@ -1,0 +1,20 @@
+/**
+ * "Yet Another Multicolumn Layout" - YAML CSS Framework
+ *
+ * YAML-Addon:URI Schemes
+ */
+@media all {
+	
+	a[href^="tel:"]:BEFORE {
+		content: "☎ ";
+	}
+
+	a[href^="bitcoin:"]:BEFORE {
+		content: "B⃦ ";
+	}
+
+	a[href^="mailto:"]:BEFORE {
+		content: "✉ ";
+	}
+
+}


### PR DESCRIPTION
The URI Schemes add-on prefixes some URI schemes with UTF-8 symbols. In this initial version these schemes:
mailto: ✉
tel: ☎
bitcoin: B⃦
