### PR TITLE
[CLEANUP] Consistently use one space after a colon in a rule in add-ons.

### DIFF
--- a/sass/yaml-sass/add-ons/accessible-tabs/_tabs.scss
+++ b/sass/yaml-sass/add-ons/accessible-tabs/_tabs.scss
@@ -1,22 +1,22 @@
 @media screen, projection {
 	.jquery_tabs {
-		margin:0 0 1.5em 0;
+		margin: 0 0 1.5em 0;
 
 		ul.tabs-list {
 			font-size: 1em;
-			display:table;
-			table-layout:fixed;
-			list-style-type:none;
+			display: table;
+			table-layout: fixed;
+			list-style-type: none;
 			margin: 0;
-			position:relative;
-			z-index:1;
+			position: relative;
+			z-index: 1;
 
 			li {
 				margin: 0 4px 0 0;
-				border:0 none;
-				display:inline;
-				float:left;
-				padding:0;
+				border: 0 none;
+				display: inline;
+				float: left;
+				padding: 0;
 
 				a {
 					font-size: 1em;
@@ -24,21 +24,21 @@
 					padding: 0.75em;
 					background: transparent;
 
-					display:block;
-					float:left;
-					font-weight:normal;
-					margin:0;
+					display: block;
+					float: left;
+					font-weight: normal;
+					margin: 0;
 
 					&:focus,
 					&:hover,
 					&:active {
-						background:#eee;
+						background: #eee;
 						border-radius: 0.2em 0.2em 0 0;
-						color:#000;
+						color: #000;
 
-						font-weight:normal;
+						font-weight: normal;
 						outline: 0 none;
-						text-decoration:none;
+						text-decoration: none;
 					}
 				}
 
@@ -47,14 +47,14 @@
 					a:focus,
 					a:hover,
 					a:active {
-						background:#fff;
-						border:1px #ccc solid;
-						border-radius:0.2em 0.2em 0 0;
-						color:#000;
+						background: #fff;
+						border: 1px #ccc solid;
+						border-radius: 0.2em 0.2em 0 0;
+						color: #000;
 
-						border-bottom:0 none;
-						font-weight:bold;
-						text-decoration:none;
+						border-bottom: 0 none;
+						font-weight: bold;
+						text-decoration: none;
 					}
 				}
 			}
@@ -63,23 +63,23 @@
 		.content {
 			border-top: 1px #ccc solid;
 
-			clear:both;
+			clear: both;
 			padding: 0;
-			position:relative;
-			top:-1px;
-			margin-bottom:-1px;
+			position: relative;
+			top: -1px;
+			margin-bottom: -1px;
 		}
 	}
 
 	/* hiding texts visually */
 	.jquery_tabs .tabhead {
-		position:absolute;
-		left:-32768px; // LTR
+		position: absolute;
+		left: -32768px; // LTR
 	}
 	.jquery_tabs .current-info,
 	.jquery_tabs .accessibletabsanchor {
-		left:-999em;
-		position:absolute;
+		left: -999em;
+		position: absolute;
 	}
 
    /** Avoid margin collapsing to enable correct sync of all tabs
@@ -94,7 +94,7 @@
 		border-bottom: 1px transparent solid;
 		border-top: 1px transparent solid;
 		padding-top: 1.5em;
-		*overflow:hidden;
+		*overflow: hidden;
 	}
 
 	/** Containing floats adjustment and stability fixes for Internet Explorer
@@ -106,9 +106,9 @@
 	 */
 
 	* html .jquery_tabs {
-		zoom:1;
-		width:auto;
-		position:relative;
+		zoom: 1;
+		width: auto;
+		position: relative;
 
 		// IE < 7 don't support transparent borders
 	 	.tab-content {
@@ -117,12 +117,12 @@
 		}
 
 		.content {
-			z-index:-1;
+			z-index: -1;
 		}
 	}
 
-	*+html .jquery_tabs { zoom:1; width:auto; }
-	.jquery_tabs * { zoom:1; }
+	*+html .jquery_tabs { zoom: 1; width: auto; }
+	.jquery_tabs * { zoom: 1; }
 }
 
 /* Make tabs printable */

--- a/sass/yaml-sass/add-ons/microformats/_microformats.scss
+++ b/sass/yaml-sass/add-ons/microformats/_microformats.scss
@@ -4,58 +4,58 @@
 	.vcard,
 	.vevent {
 		line-height: 1.5em;
-		border:2px solid #e0e7b8 !important;
-		padding:30px 5px 5px 5px !important;
-		border-radius:8px;
-		-moz-border-radius:8px;
-		-webkit-border-radius:8px;
+		border: 2px solid #e0e7b8 !important;
+		padding: 30px 5px 5px 5px !important;
+		border-radius: 8px;
+		-moz-border-radius: 8px;
+		-webkit-border-radius: 8px;
 		margin: 0 0 1.5em 0 !important;
 		/* small IE-Fix for background images */
-		zoom:1;
+		zoom: 1;
 	}
 
 	span.vcard,
 	span.vevent {
-		padding:2px 1px 2px 70px !important;
-		margin:0 2px 0 !important;
+		padding: 2px 1px 2px 70px !important;
+		margin: 0 2px 0 !important;
 	}
 
 	.vcard {
-		background-color:#f8f8ec;
-		background-repeat:no-repeat;
-		background-position:5px 5px;
+		background-color: #f8f8ec;
+		background-repeat: no-repeat;
+		background-position: 5px 5px;
 		background-image: url(icons/hcard.png) !important;
 		background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAD0AAAAQCAMAAACSjoczAAAAsVBMVEVcjAFmmQb4+Ozd5sGnw2q5z4fv8t56piLU4bJwoBSwyXmMsj+VuE3C1ZWDrDDm7M/L26SOuziu4xpqnQeLtzao3RWVzQGNxQSm2xJ0qwyr4BeevlxjlQS47CJ1rQ2JtjWRyQKTvz1wpQrB8zFuowmf1Q14rwyFvAeLwwW88CWz5x206B+JwAZ9tAqbzRRrlhmazwij2BCBuAmZxjqi1Bh8rCP///9fjwKWzAWs3SGdzxWFTyrgAAABPElEQVR4XpXQ1W7EMBCG0cyYHaZlZipz3//B6tlkt03Vi+ZTbqzoyL/s4bXlfn88vmKbat3pODw+ZoOPtpow6fEhG/R6LXWapjibzXB5yMpy/dxOF5MJ6S4us/Jhff95AbFm/9MFdrtOE36/rQDzASBsgjhpUqad7vcrjSVVAWkihlI2te83NdiznuJut+vgjyzEBCRXRiCCUCZECwB6aAyn/wYsrfOKxWKKp9N2+3jj2tTXREhxkwhIEFQSgIyjSEuhBWi0IDRjMNSkX7DGm01T0z1RQBO1M7Sccd+dFL8uX61WiE/UfD7HKgHsT63Bug/NT52n+CtpjNBJXC+vdaC0O1mHOISaoQmYV+R5fnfpyuOhAaUlN0rgRTMF0gceWXpNEBganzQAjEZvLtKt8oqzddrzvPYai++wbV80NCCamQ5vZwAAAABJRU5ErkJggg==') !important;
 
 		a {
-			padding-left:11px;
+			padding-left: 11px;
 			background: url(icons/external_link.png) top left no-repeat;
 			background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAANAQMAAACn5x0BAAAABlBMVEX///9jlQQUCBxBAAAAAXRSTlMAQObYZgAAACBJREFUCB0FwaEJAAAIALA1/xYEs6/axQ0QLEUzJMkB8FxYBJy/sjNiAAAAAElFTkSuQmCC') top left no-repeat;
-			color:#679A06;
+			color: #679A06;
 		}
 
 		.adr {
-			display:block;
-			margin:0.5em 0;
+			display: block;
+			margin: 0.5em 0;
 		}
 
 		.email {
-			font-family:Consolas, "Lucida Console", "Andale Mono", "Bitstream Vera Sans Mono", "Courier New", Courier;
+			font-family: Consolas, "Lucida Console", "Andale Mono", "Bitstream Vera Sans Mono", "Courier New", Courier;
 		}
 	}
 
 
 	.vevent {
-		background:#f8f8ec url(icons/hcalendar.png) 5px 5px no-repeat !important;
+		background: #f8f8ec url(icons/hcalendar.png) 5px 5px no-repeat !important;
 		background: #f8f8ec url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAQCAMAAABjhdy+AAAAtFBMVEVcjAH4+OxmmQa5z4ewyXnU4bJwoBSMsj/d5sGVzQFqnQeLtzbm7M/v8t6Ouziu4xp6piKo3RWNxQSLwwXC1ZXL26S06B9jlQR0qwyJtjWr4BeDrDCJwAanw2q47CKVuE11rQ3B8zGevlyRyQKj2BBwpQp4rwyFvAeazwi88CVuowmz5x2m2xKf1Q1rlhmi1Bh9tAqBuAn///+Zxjqe1AyWzAVfjwJ8rCOTvz2s3SGdzxWbzRS/OR+KAAABFklEQVR4Xo3P1W4EMQyG0fwODcMyM0OZ+/7vVc80u6tWq3Y+KXc+siNwbrrdtloP+DdHfJ/FqJX23qsSvyCjfdo7HKqQJEkwn88x3ad5frytQMLJpCA1TNN8cdx8lCDSXPwHCVGrMckXT5vnz5Io4vQ10IyYdDrfBHkRHMH1NOmSdFGv1324ziSmIcBPGiOhqWEyD0RkRbhcdjEYrNf3d9zqRKy1GGdoUtQ0niatyeqsD0nSK8grnFitzkQpxfPerI+xsZYUKyhyh+12O+CRe+Pw4y9GmQbvYq5/kSDBJUe01hGGhmI0SGoJRzxSkQiDILg5dSGc4oEZAJlRP3YEQ1IFIaJ2+4VjUiERloCJEKIiQXgJlfoCe5IaqIOvDWoAAAAASUVORK5CYII=') 5px 5px no-repeat !important;
 	}
 
 	.vevent {
 		a {
-			padding-left:11px;
+			padding-left: 11px;
 			background: url(icons/external_link.png) top left no-repeat;
 			background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAANAQMAAACn5x0BAAAABlBMVEX///9jlQQUCBxBAAAAAXRSTlMAQObYZgAAACBJREFUCB0FwaEJAAAIALA1/xYEs6/axQ0QLEUzJMkB8FxYBJy/sjNiAAAAAElFTkSuQmCC') top left no-repeat;
-			color:#679A06;
+			color: #679A06;
 		}
 
 		p {
@@ -63,95 +63,95 @@
 		}
 
 		.description {
-			display:block;
-			margin-top:1em;
+			display: block;
+			margin-top: 1em;
 		}
 
 		.location {
-			display:block;
-			color:#679A06;
+			display: block;
+			color: #679A06;
 		}
 
 		.summary {
-			display:block;
-			color:#679A06;
-			font-weight:bold;
+			display: block;
+			color: #679A06;
+			font-weight: bold;
 		}
 	}
 
 	/* XFN relationship */
 
 	a.xfnRelationship {
-		padding-right:26px;
+		padding-right: 26px;
 		background-image: url(xfn/xfn-small.png);
 		background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABcAAAAOCAMAAADzLXfBAAAAq1BMVEXGxsb///+Zzg6NxAqVzA32+u6JxAqKwxfK6zya0xCh1xKFwQrt9tyk2ROX0Q+Fvgi75SvU6aya0h6z4SOl2hSQxgqDvwmq0xWd0hCYyQ6MwwmRzQ1/uwi32XvJ4puizxKu1RiRxwyg1xONyQuUyCrD4oye1RGLwgfF6TeIwQiEvQe/5jHc7b3O7EGSyguu1mq22hrE5H6122vD5zSIvxu833zi7syUyxuo3RZV5oaGAAAAAXRSTlMAQObYZgAAAN1JREFUeF51kNVuxWAMg+sfi8wMh/mM9/5PtrS7mzTLiZUvuYphuDr/K+0u+DtJwsvb0TRvN9M0j5cwTGihbS/1PC9Nqa+xlmPktj371mxZlu/7e3Jp7e2Fz3aMKJZRA6CBjF/gzzPxsmRfEjux6VWzgcQHNmVJnDF2f0jN1PXxqrCTHThj+cqnDluhADjougiKMboX4q4lIu70rSLeSjhC0P2UbdG/y2vbn6YAnfpEME3EeXY4B+RTUHMKHpwPPMsNzVfV5KV+h9qhP2RVNRTFOD4XjWMxDJV2//vbD/KGFzMfCBH8AAAAAElFTkSuQmCC');
-		background-repeat:no-repeat;
-		background-position:right;
+		background-repeat: no-repeat;
+		background-position: right;
 
 		&[rel~="colleague"],
 		&[rel~="co-worker"] {
-			padding-right:21px;
+			padding-right: 21px;
 			background-image: url(icons/xfn/xfn-colleague.png);
 			background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAOCAMAAAAVBLyFAAAAYFBMVEXGxsa+z+woYcAmYL++z+u9zuvZ4/TO2/H///++zuvd5/WgueLy9fvR3fJVg87u8/mRr9/G1e7q8Pk0asP7/P5diM9CdMfC0u1chs+0yOmdt+Ln7fh5nNlQfsxPfstdiNANDsYBAAAAAXRSTlMAQObYZgAAAI5JREFUeF5tUNcKw0AMszxuZe90//9f9o7QkkL1IiHkSeQMagoDEA3mspPCD5IjFL4IszU6Fg3SQi9m3jvzRSvFQguzLB38kcKRkm/KjsK7iPRJ06lXvco6bsN8siruefDoPlZdrdKGVvbKN7c5GFmYmPk5PFhkmnULmlNccGUWlhAt4N9B5FAQAVWDwtEbDGwHzDGQ3uIAAAAASUVORK5CYII=');
 		}
 
 		&[rel~="met"] {
-			padding-right:32px;
+			padding-right: 32px;
 			background-image: url(icons/icon-xfn.png);
 			background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB0AAAASCAMAAACQGyXoAAAAwFBMVEXGxsb///+Fvgj2+u6JxAqh1xKKwxeRxwyNxAq32XvJ4puNyQuIwQiVzA2Dvwnt9tzD4oyZzg6SyguMwwmRzQ2a0xCFwQqizxKX0Q+u1RjU6ayg1xOq0xWe1RG122uu1mqQxgqd0hCl0U2YyQ6a0h6LwgfO7EF/uwiUyCqz4SPK6zyl2hSq01a75Svc7b2k2ROEvQe/5jGYzDnD5zSc0CzE5H6833zF6TeIvxun3BOUyxvi7syo1z222hq924uo3RbH6VQeAAAAAXRSTlMAQObYZgAAAT1JREFUeF59keVunDEQRX2NHzLDMjMHiu//Vp1ttpUiJTnSjD33eH6ZsXCrg4/Q45Ckjn+vVrvd6fK8Xq/n8zn158tpt1vlOmTb6vUz4jHT6nDYHIjNho7H5dEKFqiDaqu8bfM8r4hej0qN8p5Sd9sqNUVTTUWTgbhlENP8hqptW7I9eh3hHOHqYt/v/3CBKHtCRjlnwWg0ir+JPSLfhSOz2IXA8gku5bQbE8kAQscS+0H/KhEJx4ZFcfBmjQ0sfQliW8C20UCSpV3f9xMtGjRWAWchXbKLUKCgnHaTJJEOXn7hvIAjkySAXQyAe07WmOESDn8Re7KeMRy25N/BjTFkreFwduQplcd5at0HK+XHGeUB09aD9F5/2785LdjWm/0nnb3DG7NQe8PJpCy7rq5/vlHXXVeWE0+HX//+Hw2+L1y/3yDiAAAAAElFTkSuQmCC');
 		}
 
 		&[rel~="colleague"][rel~="met"],
 		&[rel~="co-worker"][rel~="met"] {
-			padding-right:26px;
+			padding-right: 26px;
 			background-image: url(icons/xfn/xfn-colleague-met.png);
 			background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABcAAAAOCAMAAADzLXfBAAAAYFBMVEXGxsa+z+woYcAmX7+9zuv///++zuve5/XF1O6huuP7/P7Z4/RCdMfq8PjS3vLN2/E0asOxxudQfszZ5PVWg86Qr95bhs/v8/rn7fjy9ftdiNDe6PV5nNitxOe6zeqdtuISlCqmAAAAAXRSTlMAQObYZgAAAJ9JREFUeF5tkIcOwzAIRH0HHtm7e/z/XxYnalOpRboDPSMb41ylsAhqCoDCDNG56ep/I0aHnO8kHy2azwGc5nQR4eEYui8eVk4ax86Dw9b/zQfx2PiN5BIRDbZ+oH/zcy11k1JpnBl73d4tuDB1esy1mNb+c1Fz9rMciq49lfucPSljGs37EmmfxwD5pIjQA+/+avq/B1cBCFCFafV1by9mVwgBHNGRhAAAAABJRU5ErkJggg==');
 		}
 
 		&[rel~="friend"] {
-			padding-right:21px;
+			padding-right: 21px;
 			background-image: url(icons/xfn/xfn-friend.png);
 			background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAOCAMAAAAVBLyFAAAAYFBMVEXGxsYoYcC+z+wmX7++z+u9zuv////Z4/Spv+a+zuupwOZCdMfE0+7e5/X6+/3y9fszaMKfuOKtw+bo7/leidDU3/Jbhs94nNi5y+qOrNy/0OzZ5PWuxOe0yOnj6/fd5vUgjr18AAAAAXRSTlMAQObYZgAAAItJREFUeF5lzwcKwzAMBVBN7+zuef9bVmoaaKnA/vD4FhggUhYVUb8sriZd+JkugnjemPHUysNNIHvskPmwlIsTgayERulN+UOMuJGCehytdd6n/RcNFesy33snWR9OyNikLBsNU0X2/RO1rg8EGkYHZJuxL7O1KKDDekJK1orPvw9BVNFMpKpkIRFeAVEHR3zEFfkAAAAASUVORK5CYII=');
 		}
 
 		&[rel~="friend"][rel~="met"] {
-			padding-right:26px;
+			padding-right: 26px;
 			background-image: url(icons/xfn/xfn-friend-met.png);
 			background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABcAAAAOCAMAAADzLXfBAAAAYFBMVEXGxsa+z+soYcC+z+y+zusnX7+9zuupv+b////e5/Vch8/o7vn6+/2huuPE1O7U3/KpwOZCdMe/0Os0acKuxOfy9fuxxuff5/aVsd+0yOm6zOqtw+ayx+jZ4/R5nNi/z+u6Bqx7AAAAAXRSTlMAQObYZgAAAKRJREFUeF5t0AdOBTEMBNCMW9rW3xtw/1vikGVBAkdRrBfJGjmENwPMwH4BhnfMV+ec/la+BjQ4KdFjWur+wYGbFyUtdfn45bI5lRqxu21OX37oeCF3a/5OSrc5zo5zetE+57zSWp/3wV0v5IDuo5JOh1hbr30+p/O4kruWUaY8/OQ8kiN56XFYTt0RkJq040+K8Tvn/3vIviCBgMUMBhFhCFsOn7mzCfRhKm+OAAAAAElFTkSuQmCC');
 		}
 
 		&[rel~="sweetheart"] {
-			padding-right:21px;
+			padding-right: 21px;
 			background-image: url(icons/xfn/xfn-sweetheart.png);
 			background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAOCAMAAAAVBLyFAAAAYFBMVEXGxsYoYcD4Qq6+z+vZ4/Q/ccb4UbX///++zuu9zuv/8/rd5vUlXb5bhs/6e8b5cMLy9fv90OuhuuN4m9i2yOlSfcn8t+H8oNaJqNqzmNPD0e3w3/KtxOb0hMv7n9X9xObCRbgHAAAAAXRSTlMAQObYZgAAAHlJREFUeF51j1cKA0EMQ12mby3p9f63jDxLSEJY2UbwkD9E5FQzNuEyzIE08UeNIzW/MfOul6cxXVEH1E0ybKBEaSO1AJ2O8vhCo2d/DaGsKJvNSF0Gmd6pcfYMtfvzvT+UmJEyUFnLRUJ95I+iCFL/hWptK55wNo5etO8G3lYCx4oAAAAASUVORK5CYII=');
 		}
 
 		&[rel~="sweetheart"][rel~="met"] {
-			padding-right:26px;
+			padding-right: 26px;
 			background-image: url(icons/xfn/xfn-sweetheart-met.png);
 			background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABcAAAAOCAMAAADzLXfBAAAAYFBMVEXGxsYoYMDg5vX4Qq6+z+z///+9zutCdMfY4vT/8vpahc7y9fuhuuP4TrMlXb76ccL90Ov6esWxxuf9xOb5Wbc0asT8uOKyx+i2yel4nNj8odeJqNqzmNOtw+b7n9X3gMlS9TiMAAAAAXRSTlMAQObYZgAAAINJREFUeF6N0McKAzEMRVE9FZepJb3//19GTGK8GAI54M1F2EZEKTjV9ehHYM9sW8wUzD0AnGfZWaGk5hoAzSTjHz1s+4IyfwFwu8rTY7ITrPQ2InK/z96xoN7fAdBRJnMo77ZdhBua+2s+ZlsF7wd8DcjS13+iMpEy/2sPlLQqu2N6A+dbBzWluY7VAAAAAElFTkSuQmCC');
 		}
 
 		&[rel~="child"] {
-			padding-right:21px;
+			padding-right: 21px;
 			background-image: url(icons/xfn/xfn-child.png);
 			background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAANCAMAAACTkM4rAAAAvVBMVEXM2e/B0Oz///++zuvA0OzAz+u+zuvA0Oy/z+vz9vsoYcChwv/q7/n////p7vi+zuszasbn7viVseCkxP/+//87b8bz9vzs8fltlNTt9P/r8Pnm7/+ZtOGateFrk9QsZMGnxv/7/P/8/f46bsXa5PS60v/6/P9xltUuZcLQ3PHT4v+yzf/w9PuLqd0zacM3bMRymN2CqO6xzf/8/f9Fdsh6o+uox//N3/+txOfE2f81a8bG1e5ejNu20P/w9v9zpagkAAAACXRSTlP45gAUm+oS6Z4bD6DtAAAAlUlEQVQIW2WPVQ7DQAwFHY692XCZmZnx/seqk0ZJpc6Pn0Z6sg2qqStejqKbKmgGuIhYxxQXDA1siKWstDvVskyIWVgOhyYRhamSjgUe8gxZTWq3Bkf0vurBqvUS3V6h+gOi4UiIcaGCKdFsLhZ5cblac3Gz3e0PqbKc4EgZp/Ml2WjDtZRw933/GUVvFtn1+HP9/48fzYIO5ZD33dQAAAAASUVORK5CYII=');
 		}
 
 		&[rel~="parent"] {
-			padding-right:21px;
+			padding-right: 21px;
 			background-image: url(icons/xfn/xfn-parent.png);
 			background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAOCAMAAAAVBLyFAAAA3lBMVEXA0OzJ1u7Az+u+zuu+zuu/z+v///+/z+vI1u7A0OwoYcChwv////++zuvw9Prx9Puyzf/9/v7n7ffm7Pf+/v/9/v+iw//S4f3l7fyryf/7/f/f5/a30P/Y5v9nj9Pu8vspYsCPse3P4P+7zevb6P9didTc6f9Rf8x1m9n2+f+OrN6tw+qlxf/+//+VseCTte/U4//k6/d7ntgrY8E4bchql+MvZsKnxv/F2f/Z4/Q3bMQwaMSVuPnV5P+tw+ZdiNBch89Mfc9Jes9Ies9Hes5Hec5Gec6StPCQtPbQ4P5zH8oEAAAACnRSTlPk+OYREJgAmfjnFvieJgAAAK9JREFUeF5lz9WOw0AMhlGHOok9kKTMzMzLjO//QutuqipSvyvrXPmHjOuBugSemwHHtmJtuFKxaXRs2Q4IP5KnegUqV6SMfAFBliHfrdaIqM5nNgClmRrYajN1mLQCZaTMHRD7TAMmk5AcIo6ICuMUTRCnRLN5ihaISyJa5RPScr3ZIu72P0THm5xW/MTtHf53/0BEj/yE8J+eX17f3j8+v77DMPz1xXlQ0nnQ9ew/oEsSiPZewisAAAAASUVORK5CYII=');
 		}
 
 		&[rel~="spouse"] {
-			padding-right:21px;
+			padding-right: 21px;
 			background-image: url(icons/xfn/xfn-spouse.png);
 			background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAOCAMAAAAVBLyFAAABaFBMVEW+zuu+zuvAz+z///+/z+vA0Oy/z+vI1u7J1u7A0OzA0Oz///++zuvw9Prx9Pv9/v6usTfw8O+7vjv9/f3n7ffm7PfT089+f1nR1EGRkYjGxsL29vXc3Nr+/v6oqKKfojOUly/Y2NXc3NlrazHAwzySlC93eEttbzJ7fDjIyz5MTSSAgTrGyT7z8/Nub0e6vTvx8fDz8/KVl0LM0ECChChqazySkoJ8fyaRky5TVC+QkzF3eDONjy2doDJ3eDuLi36KjC3v7+6HiTZ9fyvr7vTs7/WWmTF0dTjq6uimqTRzdEKDhUWTlS/o6OaEhTqChCvo6vGCg0KlqDWysqyChDh6eyitsDdvcDK2trC3ujlyc0HHx8KqrTeBgj55eViHiS9paUijpTNcXUV9fVirrjaYmjHHx8O9vbeChDZ2eCp+f012dyxgYiS/wjy4uzp3eDK4uLP5+fjKysbExz1zc07u8fjJycX4+PfL29bJAAAAC3RSTlMPEeQAl+SZ+Pjo54Y2LlAAAADTSURBVHhebY/TjgVBAAX7Enu6B5e2bWNp27aN39+ZyWZf7p7HSiqpQzREq6N/02kloFIbrYz7HbMa1SqiN/BAzi4CRXsJ4A16YrIhHI8JzVYkKHTzIdiGCGXe42jSkWik0o5M9tbLKKHcXWHYgnKlWoOl/v7BSeiz3fFB7PUPR0bhGxufkNDk1DQwMzs3v7AILC2vyOLq2jqwsbm1Dezs7ski2z8IHLlOAqdnrvOLyytG5YjrG7PTfP/w6Hx6fpEilNTXN7/b43H7v76V1MFD/9z+AVw1IjFL8DyHAAAAAElFTkSuQmCC');
 		}
 
 		&[rel~="me"] {
-			padding-right:21px;
+			padding-right: 21px;
 			background-image: url(icons/xfn/xfn-me.png);
 			background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAOCAMAAAAVBLyFAAAAWlBMVEXGxsYoYcC+z+u+z+y9zusnYL/Z4/S+zusoYMBdiM/y9fteidDd5/QnYMDe5/VCdcihuuPy9Ps1a8SUsN+8zetdidDJ1u7Z5PV4m9hCdMeuxOc0asStw+b///+reoflAAAAAXRSTlMAQObYZgAAAH1JREFUeF5dj1cOBDEIQ7Ehbfpsr/e/5qYoH7Mg2eLJICHiSVU1Ja2Iz2T6Hmq5i1bwAnBpTIXVE4DUUUuNEW78QwCuDQWx6o8InBuihOrDiud+XNwA3DoKObKtmB3m9Bl66uQAF13Wd0d5KF2knvfL8aGpPKlUUoMZSaOXHyGOEL2qtmFaAAAAAElFTkSuQmCC');
 		}
@@ -160,7 +160,7 @@
 	/* rel-tag */
 
 	a[rel~="tag"] {
-		padding-right:32px;
+		padding-right: 32px;
 		background: url(icons/icon-rel-tag.png);
 		background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB0AAAASCAMAAACQGyXoAAAAwFBMVEXGxsb///8zcMkhXsDx9PpCf9A5dcsnYL8tZcEzasQoYcAlYsJljtJFgtOluuF1ltM9e85KiNUtbMgudMseVbgpZMFHhNNLidYoaMW3yehPjddqlNYvacVXlNtpjM7e5/UhWrxqo+FFecxbgsp+sufR2+90quM3ftCBotonZsTj6/c0es6Kqt1Pgc9Wk9vT3fHJ2PE3Zr9Xi9SrweaIo9iUs+KVrNvG1O6Fotc6gtJTkNrBzukbW7+HuOhOjNh+ntfOA5d8AAAAAXRSTlMAQObYZgAAATtJREFUeF51kdXOHDEMheMgDDLDMtPP3L7/W9Wzq6q92S+J5eOjJJZMyK4xyuK67r9gZtwBTSO66XS1Wi0Wi58bmKGeenogjehOpw65xX/i1AmXmPrzLpqoui5ygXjRr1zkRX3TqOo6I7aIvAuMPHovcBFR4T1WHHgTRYUlNs9Fs3mDzSGUZw4zTxz57rB5Cr08z4jCR0P6BG0YHqGCIJQVzKSUIdbRDRHqoyt/g+QVNbwyM9c9Yhn/lYjxQcv2jc/PXGuodABwoFKiS5HWB0sNjMztcniwKTy3lGJXMZL5MNn20E8e4FX1sAwCeM/i2BJVIg66js/1li0HpuZfAMs+K0t0HURNJswZD7uFNE3ZWCaG3UeThn3fg7k4Qca2ZRwnyX6/Xn8g6/0+SeLSYXocsGuuc1e3qP6f/h96Fy3YfuOuuQAAAABJRU5ErkJggg==');
 		background-repeat: no-repeat;
@@ -170,10 +170,10 @@
 	/* geo */
 
 	abbr[class~="geo"] {
-		padding-right:32px;
+		padding-right: 32px;
 		background: url(icons/icon-geo.png) no-repeat right;
 		background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB0AAAASCAMAAACQGyXoAAABF1BMVEWSxzD///+n1DSfzTKr1zWZyjGx3Det2zau2zbw9+Kk0jSgzjK62Tev1DXG5juXyTC31zbT60rW7FCh0DO32Gey1l6ayjGcyzGy3TebyjGs2TbQ5o/n9MSUyTCmzzPO5o+z3Ty/4zr6/PPD42X1+ubw+Nux2EHM6EGu1kHU6JnJ5z7r9c+v10XI44XO6kW43kbj8rmr1Tew2TvL5X2v3DfB3Tiz3zjR55mVxjCr1Tiu2TjY6qPh77nJ433C4Gy+3WvG5W3G4n2l1jXM5Ia23kOx3Dq04Dir1UC02U/S6I+t2Dey2Em12kqo1DigzjOm0zXk8cO32lW83WSt1jri8Lmp1DbB33T0+eao1zWl0zSizjS02kKx3Dmg7209AAABHUlEQVR4Xn3R1W4DQQwFUHtgmcPMzGVmZub//456U6VKpaRHGkvXV34aQD0qYRYZ0xF0yU5KJcdpN/q+7wdBQLPfaDtO6U3qED1YmYfFQGqKklRIcholWuYANEWbI2xVTVOPO1gbqMXscJitqMUaVgdqiNp0Or2EWKni1xF2srW9n1BUab8GIIRYxAshnhY+UYzDhhB4LgjdMsYOy2yU2anXkVxtI21eNwVNGLcZZOtb2Krj4/OIArXlFiN0axjGJRbeH7DQxLNu97qJhdt9vDcIAETIC2L5rneKZDWyS7MXCVFrmpzc8CkfnJimSW2C88RMnAPISUiFbzwmOZWDqBv/lYr/4cZAly7P523b8yxr+YdleZ5t512p///73zK9KpM38kTwAAAAAElFTkSuQmCC') no-repeat right;
-		border:none;
-		cursor:default;
+		border: none;
+		cursor: default;
 	}
 }

--- a/sass/yaml-sass/add-ons/rtl-support/core/_base-rtl.scss
+++ b/sass/yaml-sass/add-ons/rtl-support/core/_base-rtl.scss
@@ -31,7 +31,7 @@
 
 	/* set text flow */
 	.ym-form {
-		direction:rtl;
+		direction: rtl;
 
 		* {
 			text-align: right;
@@ -81,15 +81,15 @@
 		input,
 		textarea,
 		select {
-			float:right;
+			float: right;
 			margin-right: 0;
 			margin-left: -3px;
 		}
 
 		label,
 		.ym-label {
-			display:inline;
-			float:right;
+			display: inline;
+			float: right;
 		}
 
 		input+label {
@@ -131,7 +131,7 @@
 
 		.ym-fbox-button {
 			input {
-				float:none;
+				float: none;
 				margin-left: 1em;
 				margin-right: 0;
 			}

--- a/sass/yaml-sass/add-ons/rtl-support/navigation/_hlist-rtl.scss
+++ b/sass/yaml-sass/add-ons/rtl-support/navigation/_hlist-rtl.scss
@@ -14,15 +14,15 @@
 
 	.ym-hlist {
 		// changee direction for parent element as workaround for IE7
-		* { direction:ltr !important; }
+		* { direction: ltr !important; }
 
 		// change back direction to RTL for child elements
 		a,
-		strong { direction:rtl !important; }
+		strong { direction: rtl !important; }
 
 	  	ul {
-			position:relative;
-			float:right;
+			position: relative;
+			float: right;
 			// (en) Left margin of the first button
 			// (de) Abstand des ersten Buttons vom linken Rand
 			margin-left: 0; // Reset LTR
@@ -30,13 +30,13 @@
 
 		ul li {
 			float: right;
-			text-align:right !important;
+			text-align: right !important;
 		}
 	}
 
 	/* change back direction to RTL for child elements */
 	.ym-searchform {
-		direction:rtl !important;
-		float:left;
+		direction: rtl !important;
+		float: left;
 	}
 }

--- a/sass/yaml-sass/add-ons/rtl-support/navigation/_vlist-rtl.scss
+++ b/sass/yaml-sass/add-ons/rtl-support/navigation/_vlist-rtl.scss
@@ -12,7 +12,7 @@
 	.ym-vlist {
 		text-align: right;
 
-		li { float:right; }
+		li { float: right; }
 
 		li a,
 		li strong,

--- a/sass/yaml-sass/core/_iehacks.scss
+++ b/sass/yaml-sass/core/_iehacks.scss
@@ -15,7 +15,7 @@
 	* @app-yaml-default disabled
 	*/
 
-	/* body { background:#0f0; background-image:none; }	 */
+	/* body { background: #0f0; background-image: none; }	 */
 
 	/**
 	* Correct inline positioning for unknown HTML5 elements in IE 6 & 7
@@ -38,7 +38,7 @@
 	* @valid     no
 	*/
 
-	body { o\verflow:visible; }
+	body { o\verflow: visible; }
 
 	/**
 	* (en) HTML5 - default media element styles
@@ -47,7 +47,7 @@
 
 	article,aside,details,figcaption,figure,
 	footer,header,main,nav,section {
-		zoom:1;
+		zoom: 1;
 	}
 
 	audio,
@@ -79,16 +79,16 @@
 	*/
 
 	* html iframe,
-	* html frame { overflow:auto; }
+	* html frame { overflow: auto; }
 	* html input,
-	* html frameset { overflow:hidden; }
-	* html textarea { overflow:scroll; overflow-x:hidden; }
+	* html frameset { overflow: hidden; }
+	* html textarea { overflow: scroll; overflow-x: hidden; }
 
 	/*------------------------------------------------------------------------------------------------------*/
 
 	/**
-	* (en) Stability fixes with 'position:relative'
-	* (de) Stabilitätsverbesserungen durch 'position:relative'
+	* (en) Stability fixes with 'position: relative'
+	* (de) Stabilitätsverbesserungen durch 'position: relative'
 	*
 	* Essential for correct scaling in IE7 (body). IE5 must get static positioned body instead.
 	* Helpful to fix several possible problems in older IE versions (#main).
@@ -99,8 +99,8 @@
 	* @valid		 yes
 	*/
 
-	body, #main { position:relative; }
-	* html body { position:static; }
+	body, #main { position: relative; }
+	* html body { position: static; }
 
 	/*------------------------------------------------------------------------------------------------------*/
 
@@ -115,7 +115,7 @@
 	* @valid     yes
 	*/
 
-	.ym-clearfix { zoom:1; }	/* hasLayout aktivieren */
+	.ym-clearfix { zoom: 1; }	/* hasLayout aktivieren */
 
 	/*------------------------------------------------------------------------------------------------------*/
 
@@ -131,7 +131,7 @@
 
 	* html .ym-col1,
 	* html .ym-col2,
-	* html .ym-col3 { position:relative; }
+	* html .ym-col3 { position: relative; }
 
 	/*------------------------------------------------------------------------------------------------------*/
 
@@ -145,13 +145,13 @@
 	* @valid     no
 	*/
 
-	body { height:1%; }
-	.ym-wrapper, .ym-wbox, #header, #nav, #main, #footer { zoom:1; }	/* IE6 & IE7	*/
-	* html .ym-wrapper, * html .ym-wbox { height:1%; hei\ght:auto; }	/* IE 5.x & IE6 | IE6 only */
-	* html #header, * html #nav, * html #main, * html #footer { width:100%; wid\th:auto; }	/* IE 5.x & IE6 | IE6 only */
+	body { height: 1%; }
+	.ym-wrapper, .ym-wbox, #header, #nav, #main, #footer { zoom: 1; }	/* IE6 & IE7	*/
+	* html .ym-wrapper, * html .ym-wbox { height: 1%; hei\ght: auto; }	/* IE 5.x & IE6 | IE6 only */
+	* html #header, * html #nav, * html #main, * html #footer { width: 100%; wid\th: auto; }	/* IE 5.x & IE6 | IE6 only */
 
 	/* trigger hasLayout to force containing content */
-	.ym-gbox, .ym-gbox-left, .ym-gbox-right { height:1%; }
+	.ym-gbox, .ym-gbox-left, .ym-gbox-right { height: 1%; }
 
 	/*------------------------------------------------------------------------------------------------------*/
 
@@ -165,7 +165,7 @@
 	* @valid     yes
 	*/
 
-	* html ul, * html ol, * html dl { position:relative; }
+	* html ul, * html ol, * html dl { position: relative; }
 
 	/*------------------------------------------------------------------------------------------------------*/
 
@@ -178,7 +178,7 @@
 	* @valid     yes
 	*/
 
-	body ol li { display:list-item; }
+	body ol li { display: list-item; }
 
 	/*------------------------------------------------------------------------------------------------------*/
 
@@ -207,7 +207,7 @@
 	button, input { *overflow: visible !important; }
 	table button, table input { *overflow: auto; }
 
-	fieldset, legend { position:relative; }
+	fieldset, legend { position: relative; }
 
 	/*------------------------------------------------------------------------------------------------------*/
 
@@ -222,18 +222,18 @@
 
 	.ym-form,
 	.ym-form div,
-	.ym-form div * { zoom:1; }
+	.ym-form div * { zoom: 1; }
 
 	.ym-form {
 		// default form element width
 		input,
 		textarea {
-			width:68%;
+			width: 68%;
 			padding-left: 1% !important;
 			padding-right: 1% !important;
 		}
 		select {
-			width:70%;
+			width: 70%;
 			padding-left: 1% !important;
 			padding-right: 1% !important;
 		}
@@ -250,12 +250,12 @@
 	.ym-full {
 		input,
 		textarea {
-			width:98%;
+			width: 98%;
 			margin-right: -3px;
 		}
 
 		select {
-			width:100%;
+			width: 100%;
 			margin-right: -3px;
 		}
 	}
@@ -281,12 +281,12 @@
 
 	/**
 	* (en) Workaround for 'collapsing margin at #col3' when using CSS-property clear
-	*		 Left margin of #col3 collapses when using clear:both in 1-3-2 (or 2-3-1) layout and right column is the
+	*		 Left margin of #col3 collapses when using clear: both in 1-3-2 (or 2-3-1) layout and right column is the
 	*		 longest and left column is the shortest one. For IE6 and IE7 a special workaround was developed
 	*		 in YAML.
 	*
 	* (de) Workaround für 'kollabierenden Margin an #col3' bei Verwendung der CSS-Eigenschaft clear
-	*		 Der linke Margin von #col3 kollabiert bei der Verwendung von clear:both im 1-3-2 (oder 2-3-1) Layout
+	*		 Der linke Margin von #col3 kollabiert bei der Verwendung von clear: both im 1-3-2 (oder 2-3-1) Layout
 	*		 wenn gleichzeitig die linke Spalte die kürzeste und die rechte die längste ist. Im IE6 und IE7 lässt
 	*		 sich der Bug durch eine speziell für YAML entwickelten Workaround umgehen.
 	*
@@ -299,35 +299,35 @@
 	html .ym-ie-clearing {
 		/* (en) Only a small help for debugging */
 		/* (de) Nur eine kleine Hilfe zur Fehlersuche */
-		position:static;
+		position: static;
 
 		/* (en) Make container visible in IE */
 		/* (de) Container sichtbar machen im IE */
-		display:block;
+		display: block;
 
 		/* (en) No fix possible in IE5.x, normal clearing used instead */
 		/* (de) Kein Fix im IE5.x möglich, daher normales Clearing */
-		\clear:both;
+		\clear: both;
 
 		/* (en) forcing clearing-like behavior with a simple oversized container in IE6 & IE7*/
 		/* (de) IE-Clearing mit 100%-DIV für IE6 bzw. übergroßem Container im IE7 */
-		width:100%;
+		width: 100%;
 		line-height: 0;
-		font-size:0px;
-		margin:-2px 0 -1em 1px;
+		font-size: 0px;
+		margin: -2px 0 -1em 1px;
 	}
 
-	* html .ym-ie-clearing { margin:-2px 0 -1em 0; }
-	.ym-cbox { margin-bottom:-2px; }
+	* html .ym-ie-clearing { margin: -2px 0 -1em 0; }
+	.ym-cbox { margin-bottom: -2px; }
 
 	/* (en) avoid horizontal scrollbars in IE7 in borderless layouts because of negative margins */
 	/* (de) Vermeidung horizontaler Scrollbalken bei randabfallenden Layouts im IE7 */
-	html { margin-right:1px; }
-	* html { margin-right:0; }
+	html { margin-right: 1px; }
+	* html { margin-right: 0; }
 
 	/* (en) Bugfix:Essential for IE7 */
 	/* (de) Bugfix:Notwendig im IE7 */
-	.ym-col3 { position:relative; }
+	.ym-col3 { position: relative; }
 
 	/*------------------------------------------------------------------------------------------------------*/
 
@@ -357,32 +357,32 @@
 	* @css-for   IE 5.x/Win, IE6, IE7
 	* @valid     yes
 	*/
-	.ym-col1, .ym-col2 { display:inline; }
+	.ym-col1, .ym-col2 { display: inline; }
 
 	/* Fix for:"Linking to anchors in elements within the containing block" Problem in IE5.x & IE 6.0 */
-	.ym-grid { overflow:hidden; display:block; }
-	* html .ym-grid { overflow:visible; }
+	.ym-grid { overflow: hidden; display: block; }
+	* html .ym-grid { overflow: visible; }
 
 	.ym-gl,
 	.ym-gr { display: inline; }
 
 	/* transform CSS tables back into floats */
 	.ym-equalize .ym-gl {
-		float:left; display:inline;
-		padding-bottom:32767px;
-		margin-bottom:-32767px;
+		float: left; display: inline;
+		padding-bottom: 32767px;
+		margin-bottom: -32767px;
 	}
 
 	.ym-equalize .ym-gr {
-		float:right; margin-left:-5px; display:inline;
-		padding-bottom:32767px;
-		margin-bottom:-32767px;
+		float: right; margin-left: -5px; display: inline;
+		padding-bottom: 32767px;
+		margin-bottom: -32767px;
 	}
 
 	.no-ie-padding .ym-gl,
 	.no-ie-padding .ym-gr {
-		padding-bottom:0;
-		margin-bottom:0;
+		padding-bottom: 0;
+		margin-bottom: 0;
 	}
 
 	/*------------------------------------------------------------------------------------------------------*/
@@ -399,12 +399,12 @@
 
 	* html .ym-cbox-left,
 	* html .ym-cbox-right,
-	* html .ym-cbox { word-wrap:break-word; }
+	* html .ym-cbox { word-wrap: break-word; }
 
 	/* avoid growing widths */
 	* html .ym-gbox,
 	* html .ym-gbox-left,
-	* html .ym-gbox-right { word-wrap:break-word; o\verflow:hidden; }
+	* html .ym-gbox-right { word-wrap: break-word; o\verflow: hidden; }
 }
 
 @media print {
@@ -422,5 +422,5 @@
 	.ym-gbox,
 	.ym-gbox-left,
 	.ym-gbox-right,
-	.ym-col3 { height:1%; }
+	.ym-col3 { height: 1%; }
 }

--- a/sass/yaml-sass/core/base-modules/_accessibility.scss
+++ b/sass/yaml-sass/core/base-modules/_accessibility.scss
@@ -12,37 +12,37 @@
 	.ym-skip,
 	.ym-hideme,
 	.ym-print {
-		position:absolute;
-		top:-32768px;
-		left:-32768px; // LTR
+		position: absolute;
+		top: -32768px;
+		left: -32768px; // LTR
 	}
 
 	/* (en) make skip links visible when using tab navigation */
 	/* (de) Skip-Links für Tab-Navigation sichtbar schalten */
 	.ym-skip:focus,
 	.ym-skip:active {
-		position:static;
-		top:0;
-		left:0;
+		position: static;
+		top: 0;
+		left: 0;
 	}
 
 	/* skiplinks:technical setup */
 	.ym-skiplinks {
-		position:absolute;
-		top:0px;
-		left:-32768px;
-		z-index:1000;
-		width:100%;
-		margin:0;
-		padding:0;
-		list-style-type:none;
+		position: absolute;
+		top: 0px;
+		left: -32768px;
+		z-index: 1000;
+		width: 100%;
+		margin: 0;
+		padding: 0;
+		list-style-type: none;
 
 		.ym-skip:focus,
 		.ym-skip:active {
-			left:32768px;
-			outline:0 none;
-			position:absolute;
-			width:100%;
+			left: 32768px;
+			outline: 0 none;
+			position: absolute;
+			width: 100%;
 		}
 	}
 }

--- a/sass/yaml-sass/core/base-modules/_columns.scss
+++ b/sass/yaml-sass/core/base-modules/_columns.scss
@@ -13,9 +13,9 @@
 		@include ym-contain(dt);
 	}
 
-	.ym-col1 { float:left; width:$ym-column-width; }
-	.ym-col2 { float:right; width:$ym-column-width; }
-	.ym-col3 { width:auto; margin:0 $ym-column-width; }
+	.ym-col1 { float: left; width: $ym-column-width; }
+	.ym-col2 { float: right; width: $ym-column-width; }
+	.ym-col3 { width: auto; margin: 0 $ym-column-width; }
 
 	.ym-cbox { padding: 0 $ym-cbox-padding }
 	.ym-cbox-left { padding: 0 $ym-cbox-padding 0 0 }
@@ -23,5 +23,5 @@
 
 	/* (en) IE-Clearing: Only used in Internet Explorer, switched on in iehacks.css */
 	/* (de) IE-Clearing: Benötigt nur der Internet Explorer und über iehacks.css zugeschaltet */
-	.ym-ie-clearing { display:none; }
+	.ym-ie-clearing { display: none; }
 }

--- a/sass/yaml-sass/core/base-modules/_float-handling.scss
+++ b/sass/yaml-sass/core/base-modules/_float-handling.scss
@@ -6,16 +6,16 @@
 	/* (en) clearfix method for clearing floats */
 	/* (de) Clearfix-Methode zum Clearen der Float-Umgebungen */
 	.ym-clearfix:before {
-		content:"";
-		display:table;
+		content: "";
+		display: table;
 	}
 	.ym-clearfix:after {
-		clear:both;
-		content:".";
-		display:block;
-		font-size:0;
-		height:0;
-		visibility:hidden;
+		clear: both;
+		content: ".";
+		display: block;
+		font-size: 0;
+		height: 0;
+		visibility: hidden;
 	}
 
 	/* (en) alternative solutions to contain floats */

--- a/sass/yaml-sass/core/base-modules/_forms-core.scss
+++ b/sass/yaml-sass/core/base-modules/_forms-core.scss
@@ -14,22 +14,22 @@
 	* | /form                         |
 	* |-------------------------------|
 	*
-	* (en) Styling of forms where both label and input/select/textarea are styled with display:block;
-	* (de) Formulargestaltung, bei der sowohl label als auch input/select/textarea mit display:block; gestaltet werden
+	* (en) Styling of forms where both label and input/select/textarea are styled with display: block;
+	* (de) Formulargestaltung, bei der sowohl label als auch input/select/textarea mit display: block; gestaltet werden
 	*/
 
 	.ym-form,
-	.ym-form fieldset { overflow:hidden; }
+	.ym-form fieldset { overflow: hidden; }
 
 	.ym-form {
-		div { position:relative; }
+		div { position: relative; }
 
 		label,
 		.ym-label,
 		.ym-message {
-			position:relative;
+			position: relative;
 			line-height: 1.5;
-			display:block; //important for Safari
+			display: block; //important for Safari
 		}
 
 		.ym-message {
@@ -37,11 +37,11 @@
 		}
 
 		.ym-fbox-check label {
-			display:inline;
+			display: inline;
 		}
 
 		input,
-		textarea { cursor:text; }
+		textarea { cursor: text; }
 
 		.ym-fbox-check input,
 		input[type="image"],
@@ -49,7 +49,7 @@
 		input[type="checkbox"],
 		select,
 		label {
-			cursor:pointer;
+			cursor: pointer;
 		}
 
 		// small adjustments for Internet Explorer - all versions
@@ -61,7 +61,7 @@
 		// Versteckte Felder wirklich verstecken (sonst ggf. häßliche Lücken im Firefox)
 		input.hidden,
 		input[type=hidden] {
-			display:none !important;
+			display: none !important;
 		}
 
 		// styling containing DIV elements
@@ -71,8 +71,8 @@
 		.ym-fbox-select:before,
 		.ym-fbox-check:before,
 		.ym-fbox-button:before {
-			content:"";
-			display:table;
+			content: "";
+			display: table;
 		}
 
 		.ym-fbox:after,
@@ -80,12 +80,12 @@
 		.ym-fbox-select:after,
 		.ym-fbox-check:after,
 		.ym-fbox-button:after {
-			clear:both;
-			content:".";
-			display:block;
-			font-size:0;
-			height:0;
-			visibility:hidden;
+			clear: both;
+			content: ".";
+			display: block;
+			font-size: 0;
+			height: 0;
+			visibility: hidden;
 		}
 
 		// avoid jumping checkboxes & radiobuttons in IE8
@@ -98,7 +98,7 @@
 		input[type="checkbox"]:focus,
 		input[type="checkbox"]:hover,
 		input[type="checkbox"]:active {
-			border:0 none;
+			border: 0 none;
 		}
 
 		// styling standard form elements with 'almost' equal flexible width
@@ -108,10 +108,10 @@
 		input,
 		textarea,
 		select {
-			display:block;
-			position:relative;
+			display: block;
+			position: relative;
 			@include ym-box-sizing(border-box);
-			width:70%;
+			width: 70%;
 		}
 
 		// overrule width settings for inline form elements ...
@@ -143,8 +143,8 @@
 		.ym-fbox-button {
 			input {
 				display: inline;
-				overflow:visible;  // Fixes IE7 auto-padding bug
-				width:auto;
+				overflow: visible;  // Fixes IE7 auto-padding bug
+				width: auto;
 			}
 		}
 
@@ -191,7 +191,7 @@
 		input,
 		textarea,
 		select {
-			width:100%;
+			width: 100%;
 		}
 		.ym-fbox-wrap {
 			width: 100%;
@@ -222,15 +222,15 @@
 		input,
 		textarea,
 		select {
-			float:left;
+			float: left;
 			margin-right: -3px;
 		}
 
 		label,
 		.ym-label {
-			display:inline;
-			float:left;
-			width:30%; // Can be fixed width too | Kann auch eine fixe Angabe sein
+			display: inline;
+			float: left;
+			width: 30%; // Can be fixed width too | Kann auch eine fixe Angabe sein
 			z-index: 1;
 		}
 
@@ -238,7 +238,7 @@
 		// Checkboxen um den gleichen Wert einrücken, wie die Breite der labels
 		.ym-fbox-check input,
 		.ym-message {
-			margin-left:30%;
+			margin-left: 30%;
 		}
 
 		// reset indention for wrapped form elements ...
@@ -251,20 +251,20 @@
 			}
 
 			label {
-				float:none;
-				width:auto;
+				float: none;
+				width: auto;
 				z-index: 1;
 				margin-left: 0;
 			}
 
 			input {
 				margin-left: 0;
-				position:relative;
+				position: relative;
 			}
 		}
 
 		.ym-fbox-check {
-			position:relative;
+			position: relative;
 
 			label,
 			.ym-label {
@@ -278,7 +278,7 @@
 
 		.ym-fbox-button {
 			input {
-				float:none;
+				float: none;
 				margin-right: 1em;
 			}
 		}
@@ -291,6 +291,6 @@
 	/* global and local columnar settings for button alignment */
 	.ym-columnar fieldset .ym-fbox-button,
 	fieldset.ym-columnar .ym-fbox-button {
-		padding-left:30%;
+		padding-left: 30%;
 	}
 }

--- a/sass/yaml-sass/core/base-modules/_grids-core.scss
+++ b/sass/yaml-sass/core/base-modules/_grids-core.scss
@@ -7,45 +7,45 @@
 	.ym-grid {
 		@include ym-contain(dt);
 		list-style-type: none;
-		padding-left:0;
-		padding-right:0;
-		margin-left:0;
-		margin-right:0;
+		padding-left: 0;
+		padding-right: 0;
+		margin-left: 0;
+		margin-right: 0;
 	}
 
 	.ym-gl {
-		float:left;
+		float: left;
 		margin: 0;
 	}
 
 	.ym-gr {
-		float:right;
+		float: right;
 		margin: 0 0 0 $ym-rounding-tolerance;
 	}
 
-	.ym-g20 { width:20%; }
-	.ym-g40 { width:40%; }
-	.ym-g60 { width:60%; }
-	.ym-g80 { width:80%; }
-	.ym-g25 { width:25%; }
-	.ym-g33 { width:33.333%; }
-	.ym-g50 { width:50%; }
-	.ym-g66 { width:66.666%; }
-	.ym-g75 { width:75%; }
-	.ym-g38 { width:38.2%; }
-	.ym-g62 { width:61.8%; }
+	.ym-g20 { width: 20%; }
+	.ym-g40 { width: 40%; }
+	.ym-g60 { width: 60%; }
+	.ym-g80 { width: 80%; }
+	.ym-g25 { width: 25%; }
+	.ym-g33 { width: 33.333%; }
+	.ym-g50 { width: 50%; }
+	.ym-g66 { width: 66.666%; }
+	.ym-g75 { width: 75%; }
+	.ym-g38 { width: 38.2%; }
+	.ym-g62 { width: 61.8%; }
 
 	.ym-gbox { padding: 0 $ym-gbox-padding }
 	.ym-gbox-left { padding: 0 $ym-gbox-padding 0 0 }
 	.ym-gbox-right { padding: 0 0 0 $ym-gbox-padding }
 
-	.ym-equalize { overflow:hidden; }
+	.ym-equalize { overflow: hidden; }
 
 	.ym-equalize > [class*="ym-g"] {
-		display:table-cell;
-		float:none;
-		margin:0;
-		vertical-align:top;
+		display: table-cell;
+		float: none;
+		margin: 0;
+		vertical-align: top;
 	}
 
 	.ym-equalize > [class*="ym-g"] > [class*="ym-gbox"] {

--- a/sass/yaml-sass/core/base-modules/_normalization.scss
+++ b/sass/yaml-sass/core/base-modules/_normalization.scss
@@ -5,12 +5,12 @@
 
 	/* (en) Global reset of paddings and margins for all HTML elements */
 	/* (de) Globales Zurücksetzen der Innen- und Außenabstände für alle HTML-Elemente */
-	* { margin:0; padding:0; }
+	* { margin: 0; padding: 0; }
 
 	/* (en) Correction: margin/padding reset caused too small select boxes. */
 	/* (de) Korrektur: Das Zurücksetzen der Abstände verursacht zu kleine Selectboxen. */
-	option { padding-left:0.4em; } // LTR
-	select { padding:1px; }
+	option { padding-left: 0.4em; } // LTR
+	select { padding: 1px; }
 
 	/*
 	* (en) Global fix of the Italics bugs in IE 5.x and IE 6
@@ -22,7 +22,7 @@
 	* @valid      yes
 	*/
 
-	* html body * { overflow:visible; }
+	* html body * { overflow: visible; }
 
 	/*
 	* (en) Fix for rounding errors when scaling font sizes in older versions of Opera browser
@@ -32,11 +32,11 @@
 	*      Vorgabe der Standardfarben und Textausrichtung
 	*/
 	body {
-		font-size:100%;
+		font-size: 100%;
 
-		background:#fff;
-		color:#000;
-		text-align:left; // LTR
+		background: #fff;
+		color: #000;
+		text-align: left; // LTR
 	}
 
 	/* (en) avoid visible outlines on DIV and h[x] elements in Webkit browsers */
@@ -131,23 +131,23 @@
 	/* (en) Clear borders for <fieldset> and <img> elements */
 	/* (de) Rahmen für <fieldset> und <img> Elemente löschen */
 	fieldset,
-	img { border:0 solid; }
+	img { border: 0 solid; }
 
 	/* (en) new standard values for lists, blockquote, cite and tables */
 	/* (de) Neue Standardwerte für Listen, Zitate und Tabellen */
 	ul,
 	ol,
-	dl { margin:0 0 1em 1em; } // LTR
+	dl { margin: 0 0 1em 1em; } // LTR
 
 	li {
-		line-height:1.5em;
-		margin-left:0.8em; // LTR
+		line-height: 1.5em;
+		margin-left: 0.8em; // LTR
 	}
 
-	dt { font-weight:bold; }
-	dd { margin:0 0 1em 0.8em; } // LTR
+	dt { font-weight: bold; }
+	dd { margin: 0 0 1em 0.8em; } // LTR
 
-	blockquote { margin:0 0 1em 0.8em; } // LTR
+	blockquote { margin: 0 0 1em 0.8em; } // LTR
 	q { quotes: none; }
 
 	blockquote:before,
@@ -155,7 +155,7 @@
 	q:before,
 	q:after {
 		content: '';
-		content:none;
+		content: none;
 	}
 
 	table {

--- a/sass/yaml-sass/core/base-modules/_print-core.scss
+++ b/sass/yaml-sass/core/base-modules/_print-core.scss
@@ -4,8 +4,8 @@
 	/**
 	* @section print adjustments for core modules
 	*
-	* (en) float containment for grids. Uses display:table to avoid bugs in FF & IE
-	* (de) Floats in Grids einschließen. Verwendet display:table, um Darstellungsprobleme im FF & IE zu vermeiden
+	* (en) float containment for grids. Uses display: table to avoid bugs in FF & IE
+	* (de) Floats in Grids einschließen. Verwendet display: table, um Darstellungsprobleme im FF & IE zu vermeiden
 	*
 	* @bugfix
 	* @since     3.0
@@ -15,8 +15,8 @@
 	*/
 		.ym-grid > .ym-gl,
 		.ym-grid > .ym-gr {
-			overflow:visible;
-			display:table;
+			overflow: visible;
+			display: table;
 			table-layout: fixed
 		}
 	}
@@ -24,13 +24,13 @@
 	/* (en) make .ym-print class visible */
 	/* (de) .ym-print-Klasse sichtbar schalten */
 	.ym-print {
-		position:static;
-		left:0;
+		position: static;
+		left: 0;
 	}
 
 	/* (en) generic class to hide elements for print */
 	/* (de) Allgemeine CSS Klasse, um beliebige Elemente in der Druckausgabe auszublenden */
 	.ym-noprint {
-		display:none !important;
+		display: none !important;
 	}
 }

--- a/sass/yaml-sass/forms/_gray-theme.scss
+++ b/sass/yaml-sass/forms/_gray-theme.scss
@@ -3,25 +3,25 @@
 
 @media screen {
 	.ym-form {
-		background:#f4f4f4;
-		border:2px #fff solid;
+		background: #f4f4f4;
+		border: 2px #fff solid;
 		margin: 0 0 1.5em 0;
 		@include ym-box-shadow(0,0,4px,#ddd);
 
 		fieldset {
-			position:static;
-			background:transparent;
+			position: static;
+			background: transparent;
 			margin: 0.75em 0 0.75em 0;
 			padding: 0 0.5em;
 		}
 
 		legend {
-			background:transparent;
-			color:#000;
-			font-size:1.2em;
-			line-height:1.25em;
-			font-weight:bold;
-			padding:0 0.5em;
+			background: transparent;
+			color: #000;
+			font-size: 1.2em;
+			line-height: 1.25em;
+			font-weight: bold;
+			padding: 0 0.5em;
 		}
 
 		label,
@@ -68,7 +68,7 @@
 		}
 
 		.ym-fbox-check:focus + label {
-			color:#000;
+			color: #000;
 		}
 
 		.ym-gbox-left {
@@ -91,9 +91,9 @@
 		input,
 		textarea,
 		select {
-			border:1px solid #ddd;
+			border: 1px solid #ddd;
 			line-height: 1em;
-			font-family:Arial, Helvetica, sans-serif;
+			font-family: Arial, Helvetica, sans-serif;
 			@include ym-box-shadow(0,0,4px,#eee,inset);
 		}
 
@@ -115,14 +115,14 @@
 		input:active,
 		select:active,
 		textarea:active {
-			border:1px #888 solid;
-			background:#fff;
+			border: 1px #888 solid;
+			background: #fff;
 		}
 
 		optgroup {
-			font-family:Arial, Helvetica, sans-serif;
-			font-style:normal;
-			font-weight:bold;
+			font-family: Arial, Helvetica, sans-serif;
+			font-style: normal;
+			font-weight: bold;
 		}
 
 		.ym-fbox-check input,
@@ -134,11 +134,11 @@
 		}
 
 		.ym-message {
-			color:#666;
+			color: #666;
 			margin-bottom: 0.5em;
 		}
 		.ym-required {
-			color:#800;
+			color: #800;
 			font-weight: bold;
 		}
 

--- a/sass/yaml-sass/mixins/_yaml-mixins-core.scss
+++ b/sass/yaml-sass/mixins/_yaml-mixins-core.scss
@@ -4,9 +4,9 @@
 
 // BOX SIZING
 @mixin ym-box-sizing($type: border-box) {
-	-webkit-box-sizing:	$type;
-	-moz-box-sizing:	$type;
-	box-sizing:			$type;
+	-webkit-box-sizing: $type;
+	-moz-box-sizing: $type;
+	box-sizing: $type;
 }
 
 // BOX SHADOW
@@ -40,7 +40,7 @@
 
 @mixin ym-linear-gradient($direction: "to bottom", $start-color: #eee, $end-color: #ccc, $output: both, $fallback: $start-color) {
 	$old-direction: top;
-	$very-old-direction:"left top, left bottom";
+	$very-old-direction: "left top, left bottom";
 	$ie-direction: 0;
 
 	@if $direction == "to right" {
@@ -51,10 +51,10 @@
 
 	@if $output != "oldie" {
 		background-image: -webkit-gradient(linear, #{$very-old-direction}, color-stop(0%,$start-color), color-stop(100%,$end-color));
-		background-image:  -webkit-linear-gradient($old-direction, $start-color,$end-color);
-		background-image: 	-moz-linear-gradient($old-direction, $start-color,$end-color);
-		background-image: 	 -ms-linear-gradient($old-direction, $start-color,$end-color);
-		background-image:    		 unquote("linear-gradient(#{$direction}, #{$start-color},#{$end-color})");
+		background-image: -webkit-linear-gradient($old-direction, $start-color,$end-color);
+		background-image: -moz-linear-gradient($old-direction, $start-color,$end-color);
+		background-image: -ms-linear-gradient($old-direction, $start-color,$end-color);
+		background-image: unquote("linear-gradient(#{$direction}, #{$start-color},#{$end-color})");
 	}
 
 	@if $output != "css3" {
@@ -134,7 +134,7 @@
 @mixin ym-linearize-forms {
 	// linearization for form module
 	& label {
-		float:none;
+		float: none;
 	}
 
 	& .ym-label,
@@ -175,17 +175,17 @@
 //
 @mixin ym-clearfix {
 	&:before {
-		content:"";
-		display:table;
+		content: "";
+		display: table;
 	}
 
 	&:after {
-		clear:both;
-		content:".";
-		display:block;
-		font-size:0;
-		height:0;
-		visibility:hidden;
+		clear: both;
+		content: ".";
+		display: block;
+		font-size: 0;
+		height: 0;
+		visibility: hidden;
 	}
 
 	// IE < 8
@@ -232,7 +232,7 @@
 		margin-right: $margin-right;
 	}
 	[class*="ym-push-"],
-	[class*="ym-pull-"] { position:relative; }
+	[class*="ym-pull-"] { position: relative; }
 
 	@for $i from 1 through $columns {
 		.ym-#{$prefix}-#{$i} { width: $column_width * $i; }

--- a/sass/yaml-sass/navigation/_hlist.scss
+++ b/sass/yaml-sass/navigation/_hlist.scss
@@ -5,53 +5,53 @@
 	.ym-hlist {
 		/* (en) containing floats in IE */
 		/* (de) Einfassen der Floats im IE */
-		width:100%;
-		overflow:hidden;
-		position:relative;	//(en|de) Bugfix:IE - collapsing horizontal margins
-		line-height:1em;
+		width: 100%;
+		overflow: hidden;
+		position: relative;	//(en|de) Bugfix:IE - collapsing horizontal margins
+		line-height: 1em;
 		background: #222;
 
 		ul {
-			margin:0;
+			margin: 0;
 			padding: 0.5em 1.5em;
-			display:inline; // (en|de) Bugfix:IE - Doubled Float Margin Bug
-			float:left; // LTR
+			display: inline; // (en|de) Bugfix:IE - Doubled Float Margin Bug
+			float: left; // LTR
 
 			li {
-				display:inline; // (en|de) Bugfix:IE - Doubled Float Margin Bug
-				float:left; // LTR
-				font-size:1.0em;
-				line-height:1;
-				list-style-type:none;
+				display: inline; // (en|de) Bugfix:IE - Doubled Float Margin Bug
+				float: left; // LTR
+				font-size: 1.0em;
+				line-height: 1;
+				list-style-type: none;
 				margin: 0 .25em 0 0;
-				padding:0;
+				padding: 0;
 
 				a, strong {
-					background:transparent;
-					color:#aaa;
-					display:block;
-					font-size:1em;
+					background: transparent;
+					color: #aaa;
+					display: block;
+					font-size: 1em;
 					line-height: 2em;
 					padding: 0 0.5em;
-					font-weight:normal;
-					text-decoration:none;
+					font-weight: normal;
+					text-decoration: none;
 					text-shadow: 0 1px 1px rgba(0,0,0,.5);
-					width:auto;
+					width: auto;
 				}
 
 				a:focus,
 				a:hover,
 				a:active  {
 					color: #ccc;
-					background:#666;
+					background: #666;
 					background: rgba(255,255,255,.25);
 					border-radius: 0.2em;
-					text-decoration:none;
+					text-decoration: none;
 					outline: 0 none;
 				}
 
 				&.active {
-					background:#666;
+					background: #666;
 					background: rgba(255,255,255,.3);
 					border-radius: 0.2em;
 					color: #fff;
@@ -60,9 +60,9 @@
 					a:focus,
 					a:hover,
 					a:active {
-						background:transparent;
-						color:#fff;
-						text-decoration:none;
+						background: transparent;
+						color: #fff;
+						text-decoration: none;
 					}
 				}
 			}
@@ -71,7 +71,7 @@
 
 	/* ------- search form -------- */
 	.ym-searchform {
-		float:right;
+		float: right;
 		display: inline;
 		line-height: 2;
 		padding: 0.5em 1.5em;

--- a/sass/yaml-sass/navigation/_vlist.scss
+++ b/sass/yaml-sass/navigation/_vlist.scss
@@ -4,19 +4,19 @@
 
 	/* 4 navigation levels defined */
 	.ym-vlist {
-		margin:0 0 1.5em 0;
-		list-style-type:none;
+		margin: 0 0 1.5em 0;
+		list-style-type: none;
 		background: transparent;
 		border: 0 none;
 
 		ul {
-			list-style-type:none;
-			margin:0;
-			padding:0;
-			width:100%;
-			overflow:hidden;
-			border-top:2px #ddd solid;
-			border-bottom:2px #ddd solid;
+			list-style-type: none;
+			margin: 0;
+			padding: 0;
+			width: 100%;
+			overflow: hidden;
+			border-top: 2px #ddd solid;
+			border-bottom: 2px #ddd solid;
 		}
 
 		ul ul {
@@ -24,39 +24,39 @@
 		}
 
 		li {
-			float:left; // LTR
-			width:100%;
-			margin:0;
-			padding:0;
-			background-color:#fff;
+			float: left; // LTR
+			width: 100%;
+			margin: 0;
+			padding: 0;
+			background-color: #fff;
 		}
 
 		a,
 		strong,
 		span {
-			display:block;
-			padding:3px 0px 3px 10%;
-			text-decoration:none;
-			border-bottom:1px #ddd solid;
+			display: block;
+			padding: 3px 0px 3px 10%;
+			text-decoration: none;
+			border-bottom: 1px #ddd solid;
 		}
 
 		a,
 		a:visited {
-			color:#444;
+			color: #444;
 		}
 
 		li span {
-			display:block;
-			font-weight:bold;
-			border-bottom:1px #ddd solid;
+			display: block;
+			font-weight: bold;
+			border-bottom: 1px #ddd solid;
 		}
 
 		// active list element
 		li.active {
-			color:#fff;
-			background-color:#444;
+			color: #fff;
+			background-color: #444;
 			strong {
-				font-weight:bold;
+				font-weight: bold;
 			}
 		}
 
@@ -64,66 +64,66 @@
 		li {
 			a,
 			strong,
-			span { width:90%; padding-left:10%; } // LTR
+			span { width: 90%; padding-left: 10%; } // LTR
 
 			a:focus,
 			a:hover,
-			a:active { background-color:#888; color:#fff; outline: 0 none; }
+			a:active { background-color: #888; color: #fff; outline: 0 none; }
 		}
 
 		// Level 2
 		li ul li  {
 			a,
 			strong,
-			span { width:80%; padding-left:20%; } // LTR
+			span { width: 80%; padding-left: 20%; } // LTR
 
 			a,
-			a:visited { background-color:#f8f8f8; color:#333; }
+			a:visited { background-color: #f8f8f8; color: #333; }
 			a:focus,
 			a:hover,
-			a:active { background-color:#888; color:#fff; }
+			a:active { background-color: #888; color: #fff; }
 		}
 
 		// Level 3
 		li ul li ul li {
 			a,
 			strong,
-			span { width:70%; padding-left:30%; } // LTR
+			span { width: 70%; padding-left: 30%; } // LTR
 
 			a,
-			a:visited{ background-color:#f0f0f0; color:#222; }
+			a:visited{ background-color: #f0f0f0; color: #222; }
 			a:focus,
 			a:hover,
-			a:active { background-color:#888; color:#fff; }
+			a:active { background-color: #888; color: #fff; }
 		}
 
 		// Level 4
 		li ul li ul li ul li {
 			a,
 			strong,
-			span { width:60%; padding-left:40%; } // LTR
+			span { width: 60%; padding-left: 40%; } // LTR
 
 			a,
-			a:visited { background-color:#e8e8e8; color:#111; }
+			a:visited { background-color: #e8e8e8; color: #111; }
 			a:focus,
 			a:hover,
-			a:active { background-color:#888; color:#fff; }
+			a:active { background-color: #888; color: #fff; }
 		}
 	}
 
 	/* title */
 	.ym-vtitle {
-		font-weight:bold;
-		font-size:100%;
-		width:90%;
-		padding:3px 0px 3px 10%; // LTR
-		margin:0;
-		color:#444;
-		background-color:#fff;
-		border-top:2px #ddd solid;
+		font-weight: bold;
+		font-size: 100%;
+		width: 90%;
+		padding: 3px 0px 3px 10%; // LTR
+		margin: 0;
+		color: #444;
+		background-color: #fff;
+		border-top: 2px #ddd solid;
 
 		& + ul {
-			border-top:4px #888 solid;
+			border-top: 4px #888 solid;
 		}
 	}
 }

--- a/sass/yaml-sass/print/_print.scss
+++ b/sass/yaml-sass/print/_print.scss
@@ -17,7 +17,7 @@
 	/* (de) Für den Druck nicht benötigte Container des Layouts abschalten */
 	nav,
 	.ym-searchform {
-		display:none;
+		display: none;
 	}
 
 	/*------------------------------------------------------------------------------------------------------*/
@@ -30,7 +30,7 @@
 	h4,
 	h5,
 	h6 {
-		page-break-after:avoid;
+		page-break-after: avoid;
 	}
 
 	@if $ym-print-abbreviation == true {
@@ -41,7 +41,7 @@
 
 		abbr[title]:after,
 		acronym[title]:after {
-			content:'(' attr(title) ')';
+			content: '(' attr(title) ')';
 		}
 	}
 
@@ -52,10 +52,10 @@
 	/* (de) optionale Ausgabe der URLs von Hyperlinks */
 
 		a[href]:after {
-			content:" <URL:"attr(href)">";
-			color:#444;
-			background:inherit;
-			font-style:italic;
+			content: " <URL:"attr(href)">";
+			color: #444;
+			background: inherit;
+			font-style: italic;
 		}
 	}
 }

--- a/sass/yaml-sass/screen/_screen-FULLPAGE-layout.scss
+++ b/sass/yaml-sass/screen/_screen-FULLPAGE-layout.scss
@@ -77,12 +77,12 @@
 	.ym-skiplinks {
 		a.ym-skip:focus,
 		a.ym-skip:active {
-			color:#fff;
-			background:#333;
-			border-bottom:1px #000 solid;
-			padding:10px 0;
+			color: #fff;
+			background: #333;
+			border-bottom: 1px #000 solid;
+			padding: 10px 0;
 			text-align: center;
-			text-decoration:none;
+			text-decoration: none;
 		}
 	}
 }
@@ -118,7 +118,7 @@
 	}
 
 	.ym-searchform {
-		display:block;
+		display: block;
 		float: none;
 		width: auto;
 		text-align: right;
@@ -159,7 +159,7 @@
 	.ym-searchform,
 	nav .ym-hlist ul,
 	nav .ym-hlist li {
-		display:block;
+		display: block;
 		float: none;
 		width: auto;
 		text-align: left;

--- a/sass/yaml-sass/screen/_screen-PAGE-layout.scss
+++ b/sass/yaml-sass/screen/_screen-PAGE-layout.scss
@@ -50,25 +50,25 @@
 
 	/* Column-Set Configuration: 1-3 (sidebar right) */
 	.ym-column {
-		display:block;
-		overflow:hidden;
+		display: block;
+		overflow: hidden;
 		padding-right: 340px;
-		width:auto;
+		width: auto;
 	}
 
 	/* content - column */
 	.ym-col1 {
-		float:left;
+		float: left;
 		width: 100%;
 	}
 
 	/* sidebar - column */
 	.ym-col3 {
-		position:relative;
-		float:left;
+		position: relative;
+		float: left;
 		width: 340px;
-		margin-left:0;
-		margin-right:-340px;
+		margin-left: 0;
+		margin-right: -340px;
 	}
 
 	.ym-col1 .ym-cbox { padding: 0 0.75em 0 1.5em; }
@@ -80,12 +80,12 @@
 	.ym-skiplinks {
 		a.ym-skip:focus,
 		a.ym-skip:active {
-			color:#fff;
-			background:#333;
-			border-bottom:1px #000 solid;
-			padding:10px 0;
+			color: #fff;
+			background: #333;
+			border-bottom: 1px #000 solid;
+			padding: 10px 0;
 			text-align: center;
-			text-decoration:none;
+			text-decoration: none;
 		}
 	}
 }
@@ -109,7 +109,7 @@
 	}
 
 	.ym-searchform {
-		display:block;
+		display: block;
 		float: none;
 		width: auto;
 		padding-right: 10px;
@@ -153,7 +153,7 @@
 	.ym-searchform,
 	nav .ym-hlist ul,
 	nav .ym-hlist li {
-		display:block;
+		display: block;
 		float: none;
 		width: auto;
 		text-align: left;

--- a/sass/yaml-sass/screen/_typography.scss
+++ b/sass/yaml-sass/screen/_typography.scss
@@ -14,7 +14,7 @@
 	/* (en) reset font size for all elements to standard (16 Pixel) */
 	/* (de) Alle Schriftgrößen auf Standardgröße (16 Pixel) zurücksetzen */
 
-	html * { font-size:100%; }
+	html * { font-size: 100%; }
 
 	/**
 	* (en) reset monospaced elements to font size 16px in all browsers
@@ -108,26 +108,26 @@
 	}
 
 	ul {
-		list-style-type:disc;
+		list-style-type: disc;
 	}
 
 	ol {
-		list-style-type:decimal;
+		list-style-type: decimal;
 	}
 
 	ul ul {
-		list-style-type:circle;
-		margin-top:0;
+		list-style-type: circle;
+		margin-top: 0;
 	}
 
 	ol ol {
-		list-style-type:lower-latin;
-		margin-top:0;
+		list-style-type: lower-latin;
+		margin-top: 0;
 	}
 
 	ol ul {
-		list-style-type:circle;
-		margin-top:0;
+		list-style-type: circle;
+		margin-top: 0;
 	}
 
 	li {
@@ -137,7 +137,7 @@
 	}
 
 	dt {
-		font-weight:bold;
+		font-weight: bold;
 	}
 
 	dd {
@@ -439,7 +439,7 @@
 	}
 
 	caption {
-		font-variant:small-caps;
+		font-variant: small-caps;
 	}
 
 	th,
@@ -479,7 +479,7 @@
 		/* highlight row on mouse over */
 		tr:hover th,
 		tr:hover td {
-			background:#f8f8f8;
+			background: #f8f8f8;
 		}
 	}
 }


### PR DESCRIPTION
This fixes the following scss-lint warning:

"Colon after property should be followed by 1 space"

This is part of an effort to fix all scss-lint warnings in yaml.
